### PR TITLE
Add simple CLI calculator in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # GPTAgentCreations
+
+## Calculator
+
+This repository includes a simple command-line calculator written in Python.
+
+### Usage
+
+Run the script with Python 3 and follow the prompts:
+
+```bash
+python calculator.py
+```
+
+Enter expressions such as `2 + 3 * 4` or `10 / 3`. Type `quit` or `exit` to end the program.
+
+You can also evaluate a single expression directly:
+
+```bash
+python calculator.py "3 + 5"
+```
+
+No additional dependencies are required beyond the Python standard library.

--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,42 @@
+import sys
+
+ALLOWED_NAMES = {
+    'abs': abs,
+    'round': round,
+}
+
+def safe_eval(expr):
+    """Evaluate a math expression safely."""
+    try:
+        # restrict builtins
+        result = eval(expr, {"__builtins__": None}, ALLOWED_NAMES)
+    except Exception as e:
+        raise ValueError(str(e))
+    return result
+
+
+def main():
+    if len(sys.argv) > 1:
+        expr = " ".join(sys.argv[1:])
+        try:
+            print(safe_eval(expr))
+        except Exception as e:
+            print(f"Error: {e}")
+        return
+
+    print("Simple Calculator. Type 'quit' to exit.")
+    while True:
+        expr = input('> ')
+        if expr.lower() in ('quit', 'exit'):
+            break
+        if not expr.strip():
+            continue
+        try:
+            result = safe_eval(expr)
+            print(result)
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python command line calculator script
- document calculator usage in README

## Testing
- `python3 calculator.py "1 + 2 * 3"`
- `python3 calculator.py <<'EOF'
2+2
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68766fbd88f8832e8f6e884bd55beda0